### PR TITLE
refactor:  separate EncKey function

### DIFF
--- a/encrypt/aes-256.go
+++ b/encrypt/aes-256.go
@@ -11,15 +11,20 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-/**
-* Encrypts plaintext using AES and a given key
-* create a cipher block using the key provided
-* create a GCM instance (for encryption and authentication)
-* generate the nonce (number used once) for the operation
-* it prevents the risk of repeating the same cipher text
-* use the GCM to encrypt the password (plaintext) along with nonce
-* append the nonce to the return value to ensure same nonce will be used for decrypting
- */
+// ensuring the encription key is 32-bit size supported by aes256
+// convert it to byte slice
+func EncKey(key []byte) []byte {
+	sha := sha256.Sum256(key)
+	return sha[:]
+}
+
+// Encrypts plaintext using AES and a given key
+// create a cipher block using the key provided
+// create a GCM instance (for encryption and authentication)
+// generate the nonce (number used once) for the operation
+// it prevents the risk of repeating the same cipher text
+// use the GCM to encrypt the password (plaintext) along with nonce
+// append the nonce to the return value to ensure same nonce will be used for decrypting
 func Encrypt(key []byte, plaintext []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
@@ -38,25 +43,25 @@ func Encrypt(key []byte, plaintext []byte) ([]byte, error) {
 	return append(nonce, cipherText...), nil
 }
 
-/**
-* Hashes the master password
-* It's a KDF (Key Derivation Function)
-* convert the hashed value to a valid AES 32-bit key
- */
+// Hashes the master password
+// It's a KDF (Key Derivation Function)
+// convert the hashed value to a valid AES 32-bit key
 func HashPassword(password string) ([]byte, error) {
 	hashed, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return nil, err
 	}
-	hash := sha256.Sum256(hashed)
-	return hash[:], nil
+
+	return hashed, nil
 }
 
-/**
-* Decrypts the ciphtertext using key
-* The ciphertext contains nonce and the ciphertext itself
-* use GCM to decrypt the ciphertext using the extracted nonce
- */
+func VerifyPassword(hashed []byte, password string) error {
+	return bcrypt.CompareHashAndPassword(hashed, []byte(password))
+}
+
+// Decrypts the ciphtertext using key
+// The ciphertext contains nonce and the ciphertext itself
+// use GCM to decrypt the ciphertext using the extracted nonce
 func Decrypt(ciphertext []byte, key []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -8,10 +8,11 @@ import (
 
 func main() {
 	//create a master password
-	masterPassword := []byte("adminadmin")
+	masterPassword := "adminadmin"
 
-	//create devired key for the master password
-	key, err := encrypt.HashPassword(string(masterPassword))
+	//create hashed key for the master password
+	key, err := encrypt.HashPassword(masterPassword)
+	key = encrypt.EncKey(key)
 	if err != nil {
 		fmt.Printf("Error hashing password : %s", err)
 	}
@@ -37,5 +38,13 @@ func main() {
 		fmt.Printf("Error decrypting  : %s\n", err)
 	}
 	fmt.Printf("Decrypted password : %s", plaintext)
+
+	//authentication
+	auth := encrypt.VerifyPassword(key, masterPassword)
+	if auth == nil {
+		fmt.Println("You are successfuly authenticated")
+	} else {
+		fmt.Println("Wrong credentials")
+	}
 
 }


### PR DESCRIPTION
We use bcrypt to hash the master password to get the KDF or Key Derivation Function.
But bcrypt hash always return 60-bit size of data that is not supported by AES256 Algorithm. 
So, we create a function to convert it to the correct size.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added enhanced encryption key support for AES256.
	- Introduced password verification functionality.
- **Refactor**
	- Updated key generation and authentication processes in the main application flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->